### PR TITLE
docs: #3 Github issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/github-issue-template.md
+++ b/.github/ISSUE_TEMPLATE/github-issue-template.md
@@ -1,0 +1,15 @@
+---
+name: Github issue template
+about: Github issue  등록 공통 템플릿.
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+## 목적
+>
+## 작업 상세 내용
+- [ ] Bug Issue
+- [X] Test Code 
+## 참고 사항


### PR DESCRIPTION
## #3 Github issue 공통 템플릿 추가 

Github issue를 좀 더 체계적이고 쉽게 작성하기 위해 template을 추가한다.
* [Github - About issues](https://docs.github.com/en/issues/tracking-your-work-with-issues/planning-and-tracking-work-for-your-team-or-project)

### issue 공통 템플릿을 기반으로 등록한다.
>공통 템플릿을 기반을 두지만 추가 요구사항이나 다른 issue를 등록할 땐 수정하도록 한다.