### PR TITLE
#9 회원 탈퇴 구현

### DIFF
--- a/http/lala.http
+++ b/http/lala.http
@@ -9,3 +9,12 @@ Content-Type: application/json
   "name": "http_name",
   "email": "testleehan@gmail.com"
 }
+
+### 회원 탈퇴
+DELETE http://localhost:8080/members/2
+Content-Type: application/json
+
+{
+  "loginId": "http_test",
+  "password": "password_test!!@@##"
+}

--- a/src/main/java/com/project/lala/common/encrytion/SHA512EncryptionService.java
+++ b/src/main/java/com/project/lala/common/encrytion/SHA512EncryptionService.java
@@ -3,6 +3,9 @@ package com.project.lala.common.encrytion;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 
+import org.springframework.stereotype.Component;
+
+@Component
 public class SHA512EncryptionService implements EncryptionService {
 	@Override
 	public String encrypt(String raw) {

--- a/src/main/java/com/project/lala/common/exception/AuthorizationException.java
+++ b/src/main/java/com/project/lala/common/exception/AuthorizationException.java
@@ -1,0 +1,10 @@
+package com.project.lala.common.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class AuthorizationException extends IllegalStateException {
+	private String message;
+}

--- a/src/main/java/com/project/lala/common/exception/InvalidPasswordException.java
+++ b/src/main/java/com/project/lala/common/exception/InvalidPasswordException.java
@@ -1,0 +1,7 @@
+package com.project.lala.common.exception;
+
+public class InvalidPasswordException extends RuntimeException {
+	public InvalidPasswordException() {
+		super("잘못된 비밀번호입니다.");
+	}
+}

--- a/src/main/java/com/project/lala/common/exception/MemberNotFoundException.java
+++ b/src/main/java/com/project/lala/common/exception/MemberNotFoundException.java
@@ -1,0 +1,7 @@
+package com.project.lala.common.exception;
+
+public class MemberNotFoundException extends RuntimeException {
+	public MemberNotFoundException() {
+		super("회원을 찾을 수 없습니다.");
+	}
+}

--- a/src/main/java/com/project/lala/controller/MemberController.java
+++ b/src/main/java/com/project/lala/controller/MemberController.java
@@ -1,10 +1,12 @@
 package com.project.lala.controller;
 
+import javax.servlet.http.HttpSession;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.project.lala.entity.Member;
 import com.project.lala.service.MemberService;
 
 import lombok.RequiredArgsConstructor;
@@ -17,9 +19,11 @@ public class MemberController {
 
 	private final MemberService memberService;
 
-	@DeleteMapping("/members/{id}")
-	public ResponseEntity<Void> deleteMember(@PathVariable Long id) {
-		memberService.deleteMember(id);
+	@DeleteMapping("/members")
+	public ResponseEntity<Void> deleteMember(HttpSession session) {
+		Member sessionMemberId = (Member)session.getAttribute("memberId");
+		Long memberId = sessionMemberId.getId();
+		memberService.deleteMember(memberId);
 		return ResponseEntity.noContent().build();
 	}
 

--- a/src/main/java/com/project/lala/controller/MemberController.java
+++ b/src/main/java/com/project/lala/controller/MemberController.java
@@ -1,12 +1,13 @@
 package com.project.lala.controller;
 
+import java.util.Optional;
+
 import javax.servlet.http.HttpSession;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.project.lala.entity.Member;
 import com.project.lala.service.MemberService;
 
 import lombok.RequiredArgsConstructor;
@@ -21,9 +22,11 @@ public class MemberController {
 
 	@DeleteMapping("/members")
 	public ResponseEntity<Void> deleteMember(HttpSession session) {
-		Member sessionMemberId = (Member)session.getAttribute("memberId");
-		Long memberId = sessionMemberId.getId();
+		Optional<Long> loginMember = Optional.ofNullable((Long)session.getAttribute("memberId"));
+		Long memberId = loginMember.orElseThrow(() -> new IllegalStateException("로그인 정보가 없습니다."));
+
 		memberService.deleteMember(memberId);
+		session.invalidate();
 		return ResponseEntity.noContent().build();
 	}
 

--- a/src/main/java/com/project/lala/controller/MemberController.java
+++ b/src/main/java/com/project/lala/controller/MemberController.java
@@ -1,15 +1,10 @@
 package com.project.lala.controller;
 
-import javax.servlet.http.HttpSession;
-
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.project.lala.dto.MemberDeleteRequest;
-import com.project.lala.service.AuthService;
 import com.project.lala.service.MemberService;
 
 import lombok.RequiredArgsConstructor;
@@ -21,15 +16,10 @@ import lombok.extern.slf4j.Slf4j;
 public class MemberController {
 
 	private final MemberService memberService;
-	private final AuthService authService;
 
 	@DeleteMapping("/members/{id}")
-	public ResponseEntity<Void> deleteMember(HttpSession session,
-		@RequestBody MemberDeleteRequest request, @PathVariable Long id) {
-
-		authService.authorize(session, id);
-
-		memberService.deleteMember(id, request.password());
+	public ResponseEntity<Void> deleteMember(@PathVariable Long id) {
+		memberService.deleteMember(id);
 		return ResponseEntity.noContent().build();
 	}
 

--- a/src/main/java/com/project/lala/controller/MemberController.java
+++ b/src/main/java/com/project/lala/controller/MemberController.java
@@ -1,0 +1,28 @@
+package com.project.lala.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.project.lala.dto.MemberDeleteRequest;
+import com.project.lala.service.MemberService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+public class MemberController {
+
+	private final MemberService memberService;
+
+	@DeleteMapping("/members/{id}")
+	public ResponseEntity<Void> deleteMember(@PathVariable Long id, @RequestBody MemberDeleteRequest request) {
+		memberService.deleteMember(id, request.password());
+		return ResponseEntity.noContent().build();
+	}
+
+}

--- a/src/main/java/com/project/lala/controller/MemberController.java
+++ b/src/main/java/com/project/lala/controller/MemberController.java
@@ -1,5 +1,7 @@
 package com.project.lala.controller;
 
+import javax.servlet.http.HttpSession;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -7,6 +9,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.project.lala.dto.MemberDeleteRequest;
+import com.project.lala.service.AuthService;
 import com.project.lala.service.MemberService;
 
 import lombok.RequiredArgsConstructor;
@@ -18,9 +21,14 @@ import lombok.extern.slf4j.Slf4j;
 public class MemberController {
 
 	private final MemberService memberService;
+	private final AuthService authService;
 
 	@DeleteMapping("/members/{id}")
-	public ResponseEntity<Void> deleteMember(@PathVariable Long id, @RequestBody MemberDeleteRequest request) {
+	public ResponseEntity<Void> deleteMember(HttpSession session,
+		@RequestBody MemberDeleteRequest request, @PathVariable Long id) {
+
+		authService.authorize(session, id);
+
 		memberService.deleteMember(id, request.password());
 		return ResponseEntity.noContent().build();
 	}

--- a/src/main/java/com/project/lala/dto/MemberDeleteRequest.java
+++ b/src/main/java/com/project/lala/dto/MemberDeleteRequest.java
@@ -3,8 +3,15 @@ package com.project.lala.dto;
 public record MemberDeleteRequest(String password) {
 
 	public MemberDeleteRequest {
+		String regex = "(?=.*[0-9])(?=.*[a-zA-Z])(?=.*\\W)(?=\\S+$).{8,30}";
+
 		if (password == null || password.isEmpty()) {
 			throw new IllegalArgumentException("비밀번호를 입력해주세요.");
+		}
+
+		if (!password.matches(regex)) {
+			throw new IllegalArgumentException(
+				"비밀번호는 영문 대/소문자, 숫자, 특수 기호가 1개씩 포함 되어 있어야 하며, 최소 8자 ~ 최대 30자 이내로 입력해주세요.");
 		}
 	}
 

--- a/src/main/java/com/project/lala/dto/MemberDeleteRequest.java
+++ b/src/main/java/com/project/lala/dto/MemberDeleteRequest.java
@@ -1,0 +1,11 @@
+package com.project.lala.dto;
+
+public record MemberDeleteRequest(String password) {
+
+	public MemberDeleteRequest {
+		if (password == null || password.isEmpty()) {
+			throw new IllegalArgumentException("비밀번호를 입력해주세요.");
+		}
+	}
+
+}

--- a/src/main/java/com/project/lala/dto/MemberResponse.java
+++ b/src/main/java/com/project/lala/dto/MemberResponse.java
@@ -1,0 +1,4 @@
+package com.project.lala.dto;
+
+public record MemberResponse(Long id, String email, String nickname) {
+}

--- a/src/main/java/com/project/lala/entity/Member.java
+++ b/src/main/java/com/project/lala/entity/Member.java
@@ -59,10 +59,6 @@ public class Member {
 	@Enumerated(EnumType.STRING)
 	private MemberStatus memberStatus;
 
-	public boolean matchPassword(String password) {
-		return this.password.equals(password);
-	}
-
 	@Builder
 	public Member(Long id, String loginId, String password, String nickname, String name, String email) {
 		this.id = id;
@@ -75,33 +71,4 @@ public class Member {
 		this.registeredAt = LocalDate.now();
 	}
 
-	public static Member createMember(String loginId, String password, String nickname, String name, String email) {
-		return Member.builder()
-			.loginId(loginId)
-			.password(password)
-			.nickname(nickname)
-			.name(name)
-			.email(email)
-			.build();
-	}
-
-	public void addStatus(MemberStatus memberStatus) {
-		this.memberStatus = memberStatus;
-	}
-
-	public void updatePassword(String password) {
-		this.password = password;
-	}
-
-	public void updateNickname(String nickname) {
-		this.nickname = nickname;
-	}
-
-	public void updateName(String name) {
-		this.name = name;
-	}
-
-	public void updateEmail(String email) {
-		this.email = email;
-	}
 }

--- a/src/main/java/com/project/lala/entity/Member.java
+++ b/src/main/java/com/project/lala/entity/Member.java
@@ -59,6 +59,10 @@ public class Member {
 	@Enumerated(EnumType.STRING)
 	private MemberStatus memberStatus;
 
+	public boolean matchPassword(String password) {
+		return this.password.equals(password);
+	}
+
 	@Builder
 	public Member(Long id, String loginId, String password, String nickname, String name, String email) {
 		this.id = id;

--- a/src/main/java/com/project/lala/service/AuthService.java
+++ b/src/main/java/com/project/lala/service/AuthService.java
@@ -26,15 +26,13 @@ public class AuthService {
 			throw new AuthorizationException("로그인 정보가 올바르지 않습니다.");
 		}
 
-		session.setAttribute("member", member);
+		session.setAttribute("memberId", member.getId());
 	}
 
-	public void authorize(HttpSession session, Long id) throws AuthorizationException {
-		Member member = (Member)session.getAttribute("member");
-
-		if (member == null || !member.getId().equals(id)) {
-			throw new AuthorizationException("해당 정보에 대한 권한이 없습니다.");
-		}
+	public void authorize(Long id) throws AuthorizationException {
+		memberRepository.findById(id)
+			.filter(member -> member.getId().equals(id))
+			.orElseThrow(() -> new AuthorizationException("해당 정보에 대한 권한이 없습니다."));
 	}
 
 }

--- a/src/main/java/com/project/lala/service/AuthService.java
+++ b/src/main/java/com/project/lala/service/AuthService.java
@@ -1,0 +1,40 @@
+package com.project.lala.service;
+
+import javax.servlet.http.HttpSession;
+
+import org.springframework.stereotype.Service;
+
+import com.project.lala.common.encrytion.EncryptionService;
+import com.project.lala.common.exception.AuthorizationException;
+import com.project.lala.entity.Member;
+import com.project.lala.repository.MemberRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+	private final MemberRepository memberRepository;
+	private final EncryptionService encryptionService;
+
+	public void authenticate(HttpSession session, Long id, String password) throws AuthorizationException {
+		Member member = memberRepository.findById(id)
+			.orElseThrow(() -> new AuthorizationException("로그인 정보가 올바르지 않습니다."));
+
+		if (!member.getPassword().equals(encryptionService.encrypt(password))) {
+			throw new AuthorizationException("로그인 정보가 올바르지 않습니다.");
+		}
+
+		session.setAttribute("member", member);
+	}
+
+	public void authorize(HttpSession session, Long id) throws AuthorizationException {
+		Member member = (Member)session.getAttribute("member");
+
+		if (member == null || !member.getId().equals(id)) {
+			throw new AuthorizationException("해당 정보에 대한 권한이 없습니다.");
+		}
+	}
+
+}

--- a/src/main/java/com/project/lala/service/MemberService.java
+++ b/src/main/java/com/project/lala/service/MemberService.java
@@ -9,7 +9,6 @@ import com.project.lala.common.encrytion.EncryptionService;
 import com.project.lala.common.encrytion.SHA512EncryptionService;
 import com.project.lala.common.exception.EmailDuplicationException;
 import com.project.lala.common.exception.ErrorCode;
-import com.project.lala.common.exception.InvalidPasswordException;
 import com.project.lala.common.exception.MemberDuplicationException;
 import com.project.lala.common.exception.MemberNotFoundException;
 import com.project.lala.dto.SignUpRequest;
@@ -29,7 +28,7 @@ public class MemberService {
 
 	private final MemberRepository memberRepository;
 	private final EmailAuthRepository emailAuthRepository;
-
+	private final AuthService authService;
 	private final EmailService emailService;
 	EncryptionService encryptionService = new SHA512EncryptionService();
 
@@ -47,13 +46,10 @@ public class MemberService {
 	}
 
 	@Transactional
-	public void deleteMember(Long id, String password) {
-		Member member = memberRepository.findById(id).orElseThrow(MemberNotFoundException::new);
-		String encryptedPassword = encryptionService.encrypt(password);
+	public void deleteMember(Long id) {
+		authService.authorize(id);
 
-		if (!member.matchPassword(encryptedPassword)) {
-			throw new InvalidPasswordException();
-		}
+		memberRepository.findById(id).orElseThrow(MemberNotFoundException::new);
 		memberRepository.deleteById(id);
 	}
 

--- a/src/main/java/com/project/lala/service/MemberService.java
+++ b/src/main/java/com/project/lala/service/MemberService.java
@@ -9,7 +9,9 @@ import com.project.lala.common.encrytion.EncryptionService;
 import com.project.lala.common.encrytion.SHA512EncryptionService;
 import com.project.lala.common.exception.EmailDuplicationException;
 import com.project.lala.common.exception.ErrorCode;
+import com.project.lala.common.exception.InvalidPasswordException;
 import com.project.lala.common.exception.MemberDuplicationException;
+import com.project.lala.common.exception.MemberNotFoundException;
 import com.project.lala.dto.SignUpRequest;
 import com.project.lala.dto.SignUpResponse;
 import com.project.lala.entity.EmailAuth;
@@ -42,6 +44,17 @@ public class MemberService {
 		emailService.sendEmail(emailAuth.getEmail(), emailAuth.getAuthToken());
 
 		return SignUpResponse.signUpResponse(member);
+	}
+
+	@Transactional
+	public void deleteMember(Long id, String password) {
+		Member member = memberRepository.findById(id).orElseThrow(MemberNotFoundException::new);
+		String encryptedPassword = encryptionService.encrypt(password);
+
+		if (!member.matchPassword(encryptedPassword)) {
+			throw new InvalidPasswordException();
+		}
+		memberRepository.deleteById(id);
 	}
 
 	private Member getEntity(SignUpRequest requestDto) {

--- a/src/test/java/com/project/lala/controller/MemberControllerTest.java
+++ b/src/test/java/com/project/lala/controller/MemberControllerTest.java
@@ -20,6 +20,7 @@ import com.project.lala.common.encrytion.EncryptionService;
 import com.project.lala.common.encrytion.SHA512EncryptionService;
 import com.project.lala.entity.Member;
 import com.project.lala.repository.MemberRepository;
+import com.project.lala.service.MemberService;
 
 @WebMvcTest(MemberController.class)
 @AutoConfigureMockMvc
@@ -33,6 +34,9 @@ class MemberControllerTest {
 
 	@MockBean
 	private MemberRepository memberRepository;
+
+	@MockBean
+	private MemberService memberService;
 
 	EncryptionService encryptionService = new SHA512EncryptionService();
 

--- a/src/test/java/com/project/lala/controller/MemberControllerTest.java
+++ b/src/test/java/com/project/lala/controller/MemberControllerTest.java
@@ -1,0 +1,57 @@
+package com.project.lala.controller;
+
+import static org.mockito.BDDMockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.project.lala.common.encrytion.EncryptionService;
+import com.project.lala.common.encrytion.SHA512EncryptionService;
+import com.project.lala.entity.Member;
+import com.project.lala.repository.MemberRepository;
+
+@WebMvcTest(MemberController.class)
+@AutoConfigureMockMvc
+class MemberControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	ObjectMapper objectMapper = new ObjectMapper();
+
+	@MockBean
+	private MemberRepository memberRepository;
+
+	EncryptionService encryptionService = new SHA512EncryptionService();
+
+	@Test
+	@DisplayName("회원탈퇴 - 성공")
+	void deleteMember_success() throws Exception {
+		String password = encryptionService.encrypt("testPassword");
+		Member member = new Member(1L, "testLoginId", password, "testNickname", "testName", "testEmail@email.com");
+
+		when(memberRepository.findById(1L)).thenReturn(Optional.of(member));
+
+		mockMvc.perform(delete("/members/{id}", 1L)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("{\"password\": \"" + password + "\"}"))
+			.andExpect(status().isNoContent());
+
+		memberRepository.delete(member);
+
+		verify(memberRepository, times(1)).delete(member);
+	}
+
+}

--- a/src/test/java/com/project/lala/controller/MemberControllerTest.java
+++ b/src/test/java/com/project/lala/controller/MemberControllerTest.java
@@ -51,7 +51,6 @@ class MemberControllerTest {
 			"testEmail@email.com");
 
 		MockHttpSession session = new MockHttpSession();
-		doNothing().when(authService).authorize(session, memberId);
 
 		when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
 		MemberDeleteRequest request = new MemberDeleteRequest(password);
@@ -66,24 +65,7 @@ class MemberControllerTest {
 		memberRepository.delete(member);
 
 		verify(memberRepository, times(1)).delete(member);
-		verify(authService, times(1)).authorize(session, member.getId());
-		verify(memberService, times(1)).deleteMember(member.getId(), member.getPassword());
-	}
-
-	@Test
-	@DisplayName("회원탈퇴 - 비밀번호 불일치")
-	void deleteMember_passwordMismatch() throws Exception {
-		String password = "!@testPassword1234";
-		Member member = new Member(1L, "testLoginId", password, "testNickname", "testName", "testEmail@email.com");
-
-		when(memberRepository.findById(1L)).thenReturn(Optional.of(member));
-		mockMvc.perform(delete("/members/{id}", 1L)
-				.contentType(MediaType.APPLICATION_JSON)
-				.content("{\"password\": \"" + "wrongPassword" + "\"}"))
-			.andExpect(status().isBadRequest());
-
-		verify(memberRepository, times(0)).delete(member);
-		verify(memberService, times(0)).deleteMember(member.getId(), member.getPassword());
+		verify(memberService, times(1)).deleteMember(member.getId());
 	}
 
 }

--- a/src/test/java/com/project/lala/controller/MemberControllerTest.java
+++ b/src/test/java/com/project/lala/controller/MemberControllerTest.java
@@ -13,13 +13,14 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpSession;
 import org.springframework.test.web.servlet.MockMvc;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.project.lala.common.encrytion.EncryptionService;
-import com.project.lala.common.encrytion.SHA512EncryptionService;
+import com.project.lala.dto.MemberDeleteRequest;
 import com.project.lala.entity.Member;
 import com.project.lala.repository.MemberRepository;
+import com.project.lala.service.AuthService;
 import com.project.lala.service.MemberService;
 
 @WebMvcTest(MemberController.class)
@@ -38,24 +39,51 @@ class MemberControllerTest {
 	@MockBean
 	private MemberService memberService;
 
-	EncryptionService encryptionService = new SHA512EncryptionService();
+	@MockBean
+	private AuthService authService;
 
 	@Test
 	@DisplayName("회원탈퇴 - 성공")
 	void deleteMember_success() throws Exception {
-		String password = encryptionService.encrypt("testPassword");
-		Member member = new Member(1L, "testLoginId", password, "testNickname", "testName", "testEmail@email.com");
+		Long memberId = 1L;
+		String password = "!@testPassword1234";
+		Member member = new Member(memberId, "testLoginId", password, "testNickname", "testName",
+			"testEmail@email.com");
 
-		when(memberRepository.findById(1L)).thenReturn(Optional.of(member));
+		MockHttpSession session = new MockHttpSession();
+		doNothing().when(authService).authorize(session, memberId);
 
-		mockMvc.perform(delete("/members/{id}", 1L)
+		when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
+		MemberDeleteRequest request = new MemberDeleteRequest(password);
+
+		mockMvc.perform(delete("/members/{id}", member.getId())
+				.session(session)
 				.contentType(MediaType.APPLICATION_JSON)
+				.content(new ObjectMapper().writeValueAsString(request))
 				.content("{\"password\": \"" + password + "\"}"))
 			.andExpect(status().isNoContent());
 
 		memberRepository.delete(member);
 
 		verify(memberRepository, times(1)).delete(member);
+		verify(authService, times(1)).authorize(session, member.getId());
+		verify(memberService, times(1)).deleteMember(member.getId(), member.getPassword());
+	}
+
+	@Test
+	@DisplayName("회원탈퇴 - 비밀번호 불일치")
+	void deleteMember_passwordMismatch() throws Exception {
+		String password = "!@testPassword1234";
+		Member member = new Member(1L, "testLoginId", password, "testNickname", "testName", "testEmail@email.com");
+
+		when(memberRepository.findById(1L)).thenReturn(Optional.of(member));
+		mockMvc.perform(delete("/members/{id}", 1L)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("{\"password\": \"" + "wrongPassword" + "\"}"))
+			.andExpect(status().isBadRequest());
+
+		verify(memberRepository, times(0)).delete(member);
+		verify(memberService, times(0)).deleteMember(member.getId(), member.getPassword());
 	}
 
 }

--- a/src/test/java/com/project/lala/controller/MemberControllerTest.java
+++ b/src/test/java/com/project/lala/controller/MemberControllerTest.java
@@ -51,11 +51,12 @@ class MemberControllerTest {
 			"testEmail@email.com");
 
 		MockHttpSession session = new MockHttpSession();
+		session.setAttribute("memberId", member.getId());
 
 		when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
 		MemberDeleteRequest request = new MemberDeleteRequest(password);
 
-		mockMvc.perform(delete("/members/{id}", member.getId())
+		mockMvc.perform(delete("/members")
 				.session(session)
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(new ObjectMapper().writeValueAsString(request))

--- a/src/test/java/com/project/lala/service/AuthServiceTest.java
+++ b/src/test/java/com/project/lala/service/AuthServiceTest.java
@@ -1,0 +1,53 @@
+package com.project.lala.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.Optional;
+
+import javax.servlet.http.HttpSession;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.project.lala.common.encrytion.EncryptionService;
+import com.project.lala.common.encrytion.SHA512EncryptionService;
+import com.project.lala.entity.Member;
+import com.project.lala.repository.MemberRepository;
+
+@ExtendWith(MockitoExtension.class)
+class AuthServiceTest {
+
+	@Mock
+	private MemberRepository memberRepository;
+
+	@Mock
+	private final EncryptionService encryptionService = new SHA512EncryptionService();
+
+	@Mock
+	private HttpSession session;
+
+	@InjectMocks
+	private AuthService authService;
+
+	@DisplayName("로그인 - 올바른 아이디와 비밀번호를 입력한 경우")
+	@Test
+	void authorize() {
+		Long memberId = 1L;
+		String password = "password";
+		Member member = Member.builder()
+			.id(memberId)
+			.password(password)
+			.build();
+		when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
+		when(encryptionService.encrypt(password)).thenReturn(password);
+		when(session.getAttribute("memberId")).thenReturn(memberId);
+
+		authService.authenticate(session, memberId, password);
+		assertEquals(memberId, session.getAttribute("memberId"));
+	}
+}

--- a/src/test/java/com/project/lala/service/MemberServiceTest.java
+++ b/src/test/java/com/project/lala/service/MemberServiceTest.java
@@ -17,7 +17,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import com.project.lala.common.encrytion.EncryptionService;
 import com.project.lala.common.encrytion.SHA512EncryptionService;
 import com.project.lala.common.exception.EmailDuplicationException;
-import com.project.lala.common.exception.InvalidPasswordException;
 import com.project.lala.common.exception.MemberDuplicationException;
 import com.project.lala.common.exception.MemberNotFoundException;
 import com.project.lala.dto.SignUpRequest;
@@ -40,6 +39,9 @@ class MemberServiceTest {
 
 	@InjectMocks
 	private MemberService memberService;
+
+	@Mock
+	AuthService authService;
 
 	private final EncryptionService encryptionService = new SHA512EncryptionService();
 
@@ -118,39 +120,20 @@ class MemberServiceTest {
 
 		when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
 
-		memberService.deleteMember(memberId, password);
+		memberService.deleteMember(memberId);
 
 		verify(memberRepository, times(1)).findById(memberId);
 		verify(memberRepository, times(1)).deleteById(memberId);
 	}
 
 	@Test
-	@DisplayName("회원탈퇴 - 잘못된 비밀번호")
-	void deleteMember_invalidPassword() {
-		Long memberId = 1L;
-		String password = "password";
-		Member member = Member.builder()
-			.id(memberId)
-			.password(encryptionService.encrypt("wrong_password"))
-			.build();
-
-		when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
-
-		assertThrows(InvalidPasswordException.class, () -> memberService.deleteMember(memberId, password));
-
-		verify(memberRepository, times(1)).findById(memberId);
-		verify(memberRepository, times(0)).deleteById(memberId);
-	}
-
-	@Test
 	@DisplayName("회원탈퇴 - 존재하지 않는 회원")
 	void deleteMember_notFound() {
 		Long memberId = 1L;
-		String password = "password";
 
 		when(memberRepository.findById(memberId)).thenReturn(Optional.empty());
 
-		assertThrows(MemberNotFoundException.class, () -> memberService.deleteMember(memberId, password));
+		assertThrows(MemberNotFoundException.class, () -> memberService.deleteMember(memberId));
 
 		verify(memberRepository, times(1)).findById(memberId);
 		verify(memberRepository, times(0)).deleteById(memberId);


### PR DESCRIPTION
# #9 회원 탈퇴 구현
## Description :memo:
- 회원 탈퇴 기능을 구현했습니다.

## To Reviewers :raising_hand:
- 개인정보 보호법으로 개인정보를 파기에 대해 적용했습니다.
- 개인정보 보호법을 찾아본 결과 개인정보는 수집일로부터 보유기간이 6개월이 지나면 삭제하는 것으로 알게 되었습니다.
  - 사용자에게 개인정보를 수집에 대해 동의를 받을 경우 보유한 기간까지 보관하고, 보유 기간이 만료될 경우 복원이 불가능하도록 영구 삭제를 해야 하는 것을 알게 되었습니다.
  - 보유 기간이 만료될 경우 회원 정보를 파기해야 할 때, 스케줄링을 사용해서 만료 기간에 파기할 수 있도록 구현하는 방법이 있는데 혹시 스케줄링 이 외에 다른 방법이 있는지 궁금합니다 !